### PR TITLE
Added a separate README for NuGet

### DIFF
--- a/IconCaptcha/IconCaptcha.csproj
+++ b/IconCaptcha/IconCaptcha.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath="\" />
     <None Include="icon.png" Pack="true" PackagePath="\" />
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/IconCaptcha/README.md
+++ b/IconCaptcha/README.md
@@ -1,23 +1,6 @@
-<br/>
-<p align="center">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://i.imgur.com/k8sIUQI.png">
-      <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/RMUALSz.png">
-      <img alt="IconCaptcha Logo" src="https://i.imgur.com/RMUALSz.png">
-    </picture>
-</p>
+[![IconCaptcha Logo](https://i.imgur.com/RMUALSz.png)](https://github.com/fabianwennink/IconCaptcha-ASP.NET)
 
-<p align="center">
-    <strong>A self-hosted, customizable, easy-to-implement and user-friendly captcha.</strong>
-</p>
-
-<p align="center">
-    <a href="https://github.com/fabianwennink/IconCaptcha-ASP.NET/releases"><img src="https://img.shields.io/badge/version-3.0.0-orange.svg?style=flat-square" alt="Version" /></a>
-    <a href="https://packagist.org/packages/fabianwennink/iconcaptcha"><img src="https://img.shields.io/nuget/dt/IconCaptcha?style=flat-square" alt="Latest Version on Packagist" /></a>
-    <a href="https://fabianwennink.nl/projects/IconCaptcha-ASP.NET/license"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License" /></a>
-    <a href="https://paypal.me/nlgamevideosnl"><img src="https://img.shields.io/badge/support-PayPal-lightblue.svg?style=flat-square" alt="Support via PayPal" /></a>
-    <a href="https://www.buymeacoffee.com/fabianwennink"><img src="https://img.shields.io/badge/support-Buy_Me_A_Coffee-lightblue.svg?style=flat-square" alt="Buy me a coffee" /></a>
-</p>
+**A self-hosted, customizable, easy-to-implement and user-friendly captcha.**
 
 ___
 
@@ -27,19 +10,11 @@ IconCaptcha doesn't just prioritize users; it's also developer-friendly. In just
 
 ___
 
-### [▶ Try the live demo here!](https://www.fabianwennink.nl/projects/IconCaptcha/#!demonstration)
+### **[▶ Try the live demo here!](https://www.fabianwennink.nl/projects/IconCaptcha/#!demonstration)**
 
-<img src="https://i.imgur.com/WsWdBRL.png" title="IconCaptcha widget examples" alt="IconCaptcha light and dark theme widget examples." />
+![IconCaptcha widget examples](https://i.imgur.com/WsWdBRL.png)
 
-**[Using PHP instead? Try IconCaptcha for PHP](https://github.com/fabianwennink/IconCaptcha-PHP)**
 ___
-
-## Installation
-
-Package Manager: `Install-Package IconCaptcha`   
-.NET CLI: `dotnet add package IconCaptcha`
-
-Once the package has been installed, continue with the remaining [setup instructions](https://github.com/fabianwennink/IconCaptcha-ASP.NET/wiki).
 
 ## Features
 * __User Friendly:__ The captcha uses easily understandable images instead of hard to read texts to complete the captcha.


### PR DESCRIPTION
Apparently, some formatting supported on GitHub don't seem to work on NuGet. I added a separate readme for just NuGet to still keep the original formatting on GitHub, but having a working one as well for NuGet.